### PR TITLE
Use existing java methods to filter the list

### DIFF
--- a/src/main/java/com/civservers/plugins/simplecommandblocker/Listeners1131.java
+++ b/src/main/java/com/civservers/plugins/simplecommandblocker/Listeners1131.java
@@ -29,15 +29,7 @@ public class Listeners1131 implements Listener {
 	   if (!player.isOp() && !player.hasPermission("scb.bypass") && !player.hasPermission("simplecommandblocker.bypass") && !trustList.contains(p_uuid)) {
 		   if (plugin.getConfig().getBoolean("blockTabComplete")) {
 			   List<String> allowedCommands = plugin.getConfig().getStringList("allowed_commands");
-			   List<String> cmdList = new ArrayList<>();
-			   e.getCommands().forEach(cmd -> {
-				   if (!allowedCommands.contains(cmd)) {
-					   cmdList.add(cmd);			   
-				   } else {
-					   Utilities.debug("Skipping cmd: " + cmd);
-				   }
-			   });
-			   e.getCommands().removeAll(cmdList);
+			   e.getCommands().retainAll(allowedCommands);
 		   }
 	   }
    }


### PR DESCRIPTION
At the moment, the logic in the tab handler is too complicated. This PR reduces the complexity of the code by using existing java methods instead of "reinventing the wheel".

It uses the retain function, which only keep elements from the target list in the list itself.

PS: You might want to put the whole `target` directory in the gitignore file (this is safe), it exposes that you have put your eclipse workspace inside your google drive: https://github.com/johnelder/SimpleCommandBlocker/blob/master/target/maven-status/maven-compiler-plugin/compile/default-compile/inputFiles.lst

